### PR TITLE
fix: resolve CI build errors and static analysis warnings

### DIFF
--- a/src/WindowsDesktopUse.App/DesktopUseTools.cs
+++ b/src/WindowsDesktopUse.App/DesktopUseTools.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Globalization;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 using WindowsDesktopUse.Audio;

--- a/src/WindowsDesktopUse.Audio/AudioCaptureService.cs
+++ b/src/WindowsDesktopUse.Audio/AudioCaptureService.cs
@@ -8,7 +8,7 @@ namespace WindowsDesktopUse.Audio;
 /// <summary>
 /// Service for capturing audio from system or microphone
 /// </summary>
-public class AudioCaptureService : IDisposable
+public sealed class AudioCaptureService : IDisposable
 {
     private readonly ConcurrentDictionary<string, AudioSession> _sessions = new();
     private readonly ConcurrentDictionary<string, IWaveIn> _captures = new();

--- a/src/WindowsDesktopUse.Core/Models.cs
+++ b/src/WindowsDesktopUse.Core/Models.cs
@@ -68,10 +68,19 @@ public class StreamSession : IDisposable
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
         if (!_disposed)
         {
-            Cts?.Cancel();
-            Cts?.Dispose();
+            if (disposing)
+            {
+                Cts?.Cancel();
+                Cts?.Dispose();
+            }
             _disposed = true;
         }
     }
@@ -94,8 +103,8 @@ public record CaptureTarget(
 /// List of capture targets
 /// </summary>
 public record CaptureTargets(
-    List<CaptureTarget> Monitors,
-    List<CaptureTarget> Windows,
+    IReadOnlyList<CaptureTarget> Monitors,
+    IReadOnlyList<CaptureTarget> Windows,
     int TotalCount
 );
 
@@ -194,7 +203,7 @@ public record TranscriptionSegment(
 /// </summary>
 public record TranscriptionResult(
     string SessionId,
-    List<TranscriptionSegment> Segments,
+    IReadOnlyList<TranscriptionSegment> Segments,
     string Language,
     TimeSpan Duration,
     string ModelUsed


### PR DESCRIPTION
- Add missing System.Globalization using for CultureInfo
- Mark AudioCaptureService as sealed to fix CA1063
- Implement proper IDisposable pattern in StreamSession with Dispose(bool) and GC.SuppressFinalize (CA1063, CA1816)
- Change List<T> to IReadOnlyList<T> in record types (CA1002)