### PR TITLE
fix: resolve high-priority static analysis warnings

### DIFF
--- a/src/WindowsDesktopUse.App/DesktopUseTools.cs
+++ b/src/WindowsDesktopUse.App/DesktopUseTools.cs
@@ -402,7 +402,7 @@ public static class DesktopUseTools
     [McpServerTool, Description("List available audio capture devices")]
     public static IReadOnlyList<AudioDeviceInfo> ListAudioDevices()
     {
-        return AudioCaptureService.GetAudioDevices().AsReadOnly();
+        return AudioCaptureService.GetAudioDevices();
     }
 
     [McpServerTool, Description("Start audio capture from system or microphone")]
@@ -437,7 +437,7 @@ public static class DesktopUseTools
     [McpServerTool, Description("Get list of active audio capture sessions")]
     public static IReadOnlyList<AudioSession> GetActiveAudioSessions()
     {
-        return (_audioCapture?.GetActiveSessions() ?? new List<AudioSession>()).AsReadOnly();
+        return _audioCapture?.GetActiveSessions() ?? new List<AudioSession>();
     }
 
     // ============ WHISPER SPEECH RECOGNITION TOOLS ============

--- a/src/WindowsDesktopUse.Audio/AudioCaptureService.cs
+++ b/src/WindowsDesktopUse.Audio/AudioCaptureService.cs
@@ -19,7 +19,7 @@ public sealed class AudioCaptureService : IDisposable
     /// <summary>
     /// List available audio capture devices
     /// </summary>
-    public static List<AudioDeviceInfo> GetAudioDevices()
+    public static IReadOnlyList<AudioDeviceInfo> GetAudioDevices()
     {
         var devices = new List<AudioDeviceInfo>();
 
@@ -187,7 +187,7 @@ public sealed class AudioCaptureService : IDisposable
     /// <summary>
     /// Get active audio sessions
     /// </summary>
-    public List<AudioSession> GetActiveSessions()
+    public IReadOnlyList<AudioSession> GetActiveSessions()
     {
         return _sessions.Values.Where(s => s.Status == "recording").ToList();
     }

--- a/src/WindowsDesktopUse.Screen/CaptureServices/ModernCaptureService.cs
+++ b/src/WindowsDesktopUse.Screen/CaptureServices/ModernCaptureService.cs
@@ -28,7 +28,7 @@ public interface ICaptureService
 /// <summary>
 /// Windows Graphics Capture API implementation (stub)
 /// </summary>
-public class ModernCaptureService : ICaptureService, IDisposable
+public sealed class ModernCaptureService : ICaptureService, IDisposable
 {
     public string ApiName => "Windows.Graphics.Capture (Stub)";
 
@@ -60,6 +60,7 @@ public class ModernCaptureService : ICaptureService, IDisposable
 
     public void Dispose()
     {
+        GC.SuppressFinalize(this);
     }
 
     [DllImport("user32.dll")]

--- a/src/WindowsDesktopUse.Transcription/WhisperTranscriptionService.cs
+++ b/src/WindowsDesktopUse.Transcription/WhisperTranscriptionService.cs
@@ -229,9 +229,18 @@ public class WhisperTranscriptionService : IDisposable
 
     public void Dispose()
     {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
         if (!_disposed)
         {
-            _whisperFactory?.Dispose();
+            if (disposing)
+            {
+                _whisperFactory?.Dispose();
+            }
             _disposed = true;
         }
     }


### PR DESCRIPTION
- ModernCaptureService: Mark as sealed and add GC.SuppressFinalize (CA1063, CA1816)
- WhisperTranscriptionService: Implement proper IDisposable pattern with Dispose(bool) (CA1063, CA1816)
- AudioCaptureService: Change List<T> return types to IReadOnlyList<T> (CA1002)