### PR TITLE
fix: resolve priority static analysis warnings

### DIFF
--- a/src/WindowsDesktopUse.App/DesktopUseTools.cs
+++ b/src/WindowsDesktopUse.App/DesktopUseTools.cs
@@ -63,14 +63,14 @@ public static class DesktopUseTools
     public static IReadOnlyList<MonitorInfo> ListMonitors()
     {
         if (_capture == null) throw new InvalidOperationException("ScreenCaptureService not initialized");
-        return _capture.GetMonitors().AsReadOnly();
+        return _capture.GetMonitors();
     }
 
     [McpServerTool, Description("List all visible windows with their handles, titles, and dimensions")]
     public static IReadOnlyList<WindowInfo> ListWindows()
     {
         if (_capture == null) throw new InvalidOperationException("ScreenCaptureService not initialized");
-        return _capture.GetWindows().AsReadOnly();
+        return _capture.GetWindows();
     }
 
     [McpServerTool, Description("Capture a screenshot of specified monitor or window. Returns the captured image as base64 JPEG.")]
@@ -317,7 +317,7 @@ public static class DesktopUseTools
                 throw new ArgumentException($"Unknown target type: {target}. Valid values are 'primary', 'monitor', 'window', 'region'");
         }
 
-        var base64Data = imageData.Contains(";base64,") ? imageData.Split(';')[1].Split(',')[1] : imageData;
+        var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal) ? imageData.Split(';')[1].Split(',')[1] : imageData;
 
         return new CaptureResult(
             base64Data,

--- a/src/WindowsDesktopUse.Screen/CaptureServices/ModernCaptureService.cs
+++ b/src/WindowsDesktopUse.Screen/CaptureServices/ModernCaptureService.cs
@@ -83,7 +83,7 @@ public sealed class ModernCaptureService : ICaptureService, IDisposable
 /// <summary>
 /// Hybrid capture service that tries modern API first, falls back to legacy
 /// </summary>
-public class HybridCaptureService : ICaptureService
+public sealed class HybridCaptureService : ICaptureService, IDisposable
 {
     private readonly ModernCaptureService? _modern;
     private readonly ScreenCaptureService _legacy;
@@ -175,7 +175,7 @@ public class HybridCaptureService : ICaptureService
         var hwndLong = hwnd.ToInt64();
         var imageData = _legacy.CaptureWindow(hwndLong, 1920, 80);
 
-        var base64Data = imageData.Contains(";base64,")
+        var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal)
             ? imageData.Split(',')[1]
             : imageData;
 
@@ -188,7 +188,7 @@ public class HybridCaptureService : ICaptureService
     {
         var imageData = _legacy.CaptureSingle(monitorIndex, 1920, 80);
 
-        var base64Data = imageData.Contains(";base64,")
+        var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal)
             ? imageData.Split(',')[1]
             : imageData;
 
@@ -200,5 +200,6 @@ public class HybridCaptureService : ICaptureService
     public void Dispose()
     {
         _modern?.Dispose();
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/WindowsDesktopUse.Screen/ScreenCaptureService.cs
+++ b/src/WindowsDesktopUse.Screen/ScreenCaptureService.cs
@@ -24,7 +24,7 @@ public class ScreenCaptureService
         Console.Error.WriteLine($"[Capture] Found {_monitors.Count} monitors");
     }
 
-    public List<MonitorInfo> GetMonitors() => _monitors;
+    public IReadOnlyList<MonitorInfo> GetMonitors() => _monitors;
 
     public string CaptureSingle(uint idx, int maxW, int quality)
     {
@@ -199,7 +199,7 @@ public class ScreenCaptureService
         return true;
     }
 
-    public List<WindowInfo> GetWindows()
+    public IReadOnlyList<WindowInfo> GetWindows()
     {
         var windows = new List<WindowInfo>();
         var handle = GCHandle.Alloc(windows);


### PR DESCRIPTION
- HybridCaptureService: Add IDisposable implementation and mark as sealed (CA1001, CA1063)
- ScreenCaptureService: Change List<T> return types to IReadOnlyList<T> (CA1002)
- ModernCaptureService: Add StringComparison.Ordinal to string.Contains calls (CA1307)