### PR TITLE
fix: resolve culture-dependent method warnings (CA1304, CA1305, CA130…

### DIFF
--- a/src/WindowsDesktopUse.App/DesktopUseTools.cs
+++ b/src/WindowsDesktopUse.App/DesktopUseTools.cs
@@ -625,22 +625,22 @@ public static class DesktopUseTools
             _ => KeyAction.Click
         };
 
-        var virtualKey = key.ToLowerInvariant() switch
+        var virtualKey = key.ToUpperInvariant() switch
         {
-            "enter" or "return" => InputService.VirtualKeys.Enter,
-            "tab" => InputService.VirtualKeys.Tab,
-            "escape" or "esc" => InputService.VirtualKeys.Escape,
-            "space" => InputService.VirtualKeys.Space,
-            "backspace" => InputService.VirtualKeys.Backspace,
-            "delete" or "del" => InputService.VirtualKeys.Delete,
-            "left" => InputService.VirtualKeys.Left,
-            "up" => InputService.VirtualKeys.Up,
-            "right" => InputService.VirtualKeys.Right,
-            "down" => InputService.VirtualKeys.Down,
-            "home" => InputService.VirtualKeys.Home,
-            "end" => InputService.VirtualKeys.End,
-            "pageup" => InputService.VirtualKeys.PageUp,
-            "pagedown" => InputService.VirtualKeys.PageDown,
+            "ENTER" or "RETURN" => InputService.VirtualKeys.Enter,
+            "TAB" => InputService.VirtualKeys.Tab,
+            "ESCAPE" or "ESC" => InputService.VirtualKeys.Escape,
+            "SPACE" => InputService.VirtualKeys.Space,
+            "BACKSPACE" => InputService.VirtualKeys.Backspace,
+            "DELETE" or "DEL" => InputService.VirtualKeys.Delete,
+            "LEFT" => InputService.VirtualKeys.Left,
+            "UP" => InputService.VirtualKeys.Up,
+            "RIGHT" => InputService.VirtualKeys.Right,
+            "DOWN" => InputService.VirtualKeys.Down,
+            "HOME" => InputService.VirtualKeys.Home,
+            "END" => InputService.VirtualKeys.End,
+            "PAGEUP" => InputService.VirtualKeys.PageUp,
+            "PAGEDOWN" => InputService.VirtualKeys.PageDown,
             _ => throw new ArgumentException($"Key '{key}' is not allowed or unknown. Allowed keys: enter, tab, escape, space, backspace, delete, arrow keys, home, end, pageup, pagedown")
         };
 

--- a/src/WindowsDesktopUse.App/Program.cs
+++ b/src/WindowsDesktopUse.App/Program.cs
@@ -543,7 +543,7 @@ whisperCmd.SetHandler((bool list) =>
         var availableModels = WhisperTranscriptionService.GetModelInfo();
         foreach (var kvp in availableModels)
         {
-            var size = kvp.Key.ToString().ToLower();
+            var size = kvp.Key.ToString().ToUpperInvariant();
             Console.WriteLine($"{size}: {kvp.Value.Size} - {kvp.Value.Performance}");
         }
         return;
@@ -565,7 +565,7 @@ whisperCmd.SetHandler((bool list) =>
     Console.WriteLine(GetText("Available Whisper models:", "利用可能なWhisperモデル："));
     foreach (var kvp in models)
     {
-        var size = kvp.Key.ToString().ToLower();
+        var size = kvp.Key.ToString().ToUpperInvariant();
         Console.WriteLine($"  - {size}: {kvp.Value.Size} - {kvp.Value.Performance}");
     }
     Console.WriteLine();
@@ -679,7 +679,7 @@ rootCmd.SetHandler(async (desktop, httpPort, testWhisper) =>
             int i = 1;
             foreach (var seg in result.Segments)
             {
-                var timeStr = seg.Start.ToString(@"mm\:ss");
+                var timeStr = seg.Start.ToString(@"mm\:ss", CultureInfo.InvariantCulture);
                 Console.Error.WriteLine($"[TEST] [{i:D2} {timeStr}] {seg.Text}");
                 i++;
             }

--- a/src/WindowsDesktopUse.Transcription/WhisperTranscriptionService.cs
+++ b/src/WindowsDesktopUse.Transcription/WhisperTranscriptionService.cs
@@ -26,7 +26,7 @@ public class WhisperTranscriptionService : IDisposable
     /// </summary>
     public string GetModelPath(WhisperModelSize size)
     {
-        var modelName = $"ggml-{size.ToString().ToLower()}.bin";
+        var modelName = $"ggml-{size.ToString().ToLowerInvariant()}.bin";
         return Path.Combine(_modelDirectory, modelName);
     }
 


### PR DESCRIPTION
…8, CA1311)

- Change ToLower/ToLowerInvariant to ToUpperInvariant for culture-independent string operations
- Add CultureInfo.InvariantCulture to TimeSpan.ToString
- Update switch case labels to uppercase for keyboard key matching