### PR TITLE
fix: resolve CA1806 and CA1822 warnings

### DIFF
--- a/src/WindowsDesktopUse.App/DesktopUseTools.cs
+++ b/src/WindowsDesktopUse.App/DesktopUseTools.cs
@@ -70,7 +70,7 @@ public static class DesktopUseTools
     public static IReadOnlyList<WindowInfo> ListWindows()
     {
         if (_capture == null) throw new InvalidOperationException("ScreenCaptureService not initialized");
-        return _capture.GetWindows();
+        return ScreenCaptureService.GetWindows();
     }
 
     [McpServerTool, Description("Capture a screenshot of specified monitor or window. Returns the captured image as base64 JPEG.")]
@@ -84,7 +84,7 @@ public static class DesktopUseTools
         if (_capture == null) throw new InvalidOperationException("ScreenCaptureService not initialized");
 
         var imageData = targetType == "window" && hwnd.HasValue
-            ? _capture.CaptureWindow(hwnd.Value, maxWidth, quality)
+            ? ScreenCaptureService.CaptureWindow(hwnd.Value, maxWidth, quality)
             : _capture.CaptureSingle(monitor, maxWidth, quality);
 
         var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal) ? imageData.Split(';')[1].Split(',')[1] : imageData;
@@ -104,7 +104,7 @@ public static class DesktopUseTools
     {
         if (_capture == null) throw new InvalidOperationException("ScreenCaptureService not initialized");
 
-        var imageData = _capture.CaptureWindow(hwnd, maxWidth, quality);
+        var imageData = ScreenCaptureService.CaptureWindow(hwnd, maxWidth, quality);
         var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal) ? imageData.Split(';')[1].Split(',')[1] : imageData;
 
         return new ImageContentBlock
@@ -125,7 +125,7 @@ public static class DesktopUseTools
     {
         if (_capture == null) throw new InvalidOperationException("ScreenCaptureService not initialized");
 
-        var imageData = _capture.CaptureRegion(x, y, w, h, maxWidth, quality);
+        var imageData = ScreenCaptureService.CaptureRegion(x, y, w, h, maxWidth, quality);
         var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal) ? imageData.Split(';')[1].Split(',')[1] : imageData;
 
         return new ImageContentBlock
@@ -243,7 +243,7 @@ public static class DesktopUseTools
 
         if (filter == "all" || filter == "windows")
         {
-            var windowList = _capture.GetWindows();
+            var windowList = ScreenCaptureService.GetWindows();
             windows = windowList.Select(w => new CaptureTarget(
                 "window",
                 w.Hwnd.ToString(CultureInfo.InvariantCulture),
@@ -298,7 +298,7 @@ public static class DesktopUseTools
                 if (targetId == null) throw new ArgumentNullException(nameof(targetId), "Target ID is required for window capture");
                 if (!long.TryParse(targetId, out var hwnd))
                     throw new ArgumentException("Invalid window handle");
-                imageData = _capture.CaptureWindow(hwnd, maxWidth, quality);
+                imageData = ScreenCaptureService.CaptureWindow(hwnd, maxWidth, quality);
                 actualTargetType = "window";
                 actualTargetId = hwnd.ToString(CultureInfo.InvariantCulture);
                 break;
@@ -306,7 +306,7 @@ public static class DesktopUseTools
             case CaptureTargetType.Region:
                 if (!x.HasValue || !y.HasValue || !w.HasValue || !h.HasValue)
                     throw new ArgumentException("Region capture requires x, y, w, h");
-                imageData = _capture.CaptureRegion(x.Value, y.Value, w.Value, h.Value, maxWidth, quality);
+                imageData = ScreenCaptureService.CaptureRegion(x.Value, y.Value, w.Value, h.Value, maxWidth, quality);
                 actualTargetType = "region";
                 actualTargetId = $"{x.Value},{y.Value},{w.Value},{h.Value}";
                 capturedWidth = w.Value;
@@ -576,7 +576,7 @@ public static class DesktopUseTools
         [Description("Y coordinate")] int y)
     {
         if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
-        _inputService.MoveMouse(x, y);
+        InputService.MoveMouse(x, y);
     }
 
     [McpServerTool, Description("Click mouse button")]
@@ -595,7 +595,7 @@ public static class DesktopUseTools
             _ => throw new ArgumentException($"Invalid button: {button}")
         };
 
-        _inputService.ClickMouseAsync(mouseButton, count).GetAwaiter().GetResult();
+        InputService.ClickMouseAsync(mouseButton, count).GetAwaiter().GetResult();
     }
 
     [McpServerTool, Description("Drag mouse from start to end position")]
@@ -606,7 +606,7 @@ public static class DesktopUseTools
         [Description("End Y")] int endY)
     {
         if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
-        _inputService.DragMouseAsync(startX, startY, endX, endY).GetAwaiter().GetResult();
+        InputService.DragMouseAsync(startX, startY, endX, endY).GetAwaiter().GetResult();
     }
 
     [McpServerTool, Description("Press a navigation key (security restricted)")]
@@ -644,7 +644,7 @@ public static class DesktopUseTools
             _ => throw new ArgumentException($"Key '{key}' is not allowed or unknown. Allowed keys: enter, tab, escape, space, backspace, delete, arrow keys, home, end, pageup, pagedown")
         };
 
-        _inputService.PressKey(virtualKey, keyAction);
+        InputService.PressKey(virtualKey, keyAction);
     }
 
     [McpServerTool, Description("Close a window by its handle (HWND)")]
@@ -652,6 +652,6 @@ public static class DesktopUseTools
         [Description("Window handle (HWND) to close")] long hwnd)
     {
         if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
-        _inputService.TerminateWindowProcess(new IntPtr(hwnd));
+        InputService.TerminateWindowProcess(new IntPtr(hwnd));
     }
 }

--- a/src/WindowsDesktopUse.Input/InputService.cs
+++ b/src/WindowsDesktopUse.Input/InputService.cs
@@ -97,7 +97,7 @@ public class InputService
     /// <summary>
     /// Move mouse cursor to absolute position using SendInput
     /// </summary>
-    public void MoveMouse(int x, int y)
+    public static void MoveMouse(int x, int y)
     {
         var input = new INPUT
         {
@@ -116,13 +116,13 @@ public class InputService
             }
         };
 
-        SendInput(1, new[] { input }, Marshal.SizeOf(typeof(INPUT)));
+        _ = SendInput(1, new[] { input }, Marshal.SizeOf(typeof(INPUT)));
     }
 
     /// <summary>
     /// Get current mouse position
     /// </summary>
-    public (int x, int y) GetMousePosition()
+    public static (int x, int y) GetMousePosition()
     {
         GetCursorPos(out var point);
         return (point.X, point.Y);
@@ -131,7 +131,7 @@ public class InputService
     /// <summary>
     /// Click mouse button using SendInput
     /// </summary>
-    public async Task ClickMouseAsync(MouseButton button, int count = 1)
+    public static async Task ClickMouseAsync(MouseButton button, int count = 1)
     {
         for (int i = 0; i < count; i++)
         {
@@ -179,8 +179,8 @@ public class InputService
                 }
             };
 
-            SendInput(1, new[] { downInput }, Marshal.SizeOf(typeof(INPUT)));
-            SendInput(1, new[] { upInput }, Marshal.SizeOf(typeof(INPUT)));
+            _ = SendInput(1, new[] { downInput }, Marshal.SizeOf(typeof(INPUT)));
+            _ = SendInput(1, new[] { upInput }, Marshal.SizeOf(typeof(INPUT)));
 
             if (i < count - 1)
             {
@@ -192,7 +192,7 @@ public class InputService
     /// <summary>
     /// Drag and drop from start to end position using SendInput
     /// </summary>
-    public async Task DragMouseAsync(int startX, int startY, int endX, int endY)
+    public static async Task DragMouseAsync(int startX, int startY, int endX, int endY)
     {
         // Move to start position
         MoveMouse(startX, startY);
@@ -215,7 +215,7 @@ public class InputService
                 }
             }
         };
-        SendInput(1, new[] { downInput }, Marshal.SizeOf(typeof(INPUT)));
+        _ = SendInput(1, new[] { downInput }, Marshal.SizeOf(typeof(INPUT)));
         await Task.Delay(50).ConfigureAwait(false);
 
         // Move to end position
@@ -239,14 +239,14 @@ public class InputService
                 }
             }
         };
-        SendInput(1, new[] { upInput }, Marshal.SizeOf(typeof(INPUT)));
+        _ = SendInput(1, new[] { upInput }, Marshal.SizeOf(typeof(INPUT)));
     }
 
     /// <summary>
     /// Press a virtual key using SendInput
     /// Security: Only safe navigation keys are allowed
     /// </summary>
-    public void PressKey(ushort virtualKey, KeyAction action = KeyAction.Click)
+    public static void PressKey(ushort virtualKey, KeyAction action = KeyAction.Click)
     {
         // Security check: Only allow safe navigation keys
         if (!IsAllowedKey(virtualKey))
@@ -272,9 +272,9 @@ public class InputService
     /// <summary>
     /// Terminate the process that owns the specified window
     /// </summary>
-    public void TerminateWindowProcess(IntPtr hWnd)
+    public static void TerminateWindowProcess(IntPtr hWnd)
     {
-        GetWindowThreadProcessId(hWnd, out var processId);
+        _ = GetWindowThreadProcessId(hWnd, out var processId);
         if (processId == 0) return;
 
         try
@@ -339,7 +339,7 @@ public class InputService
             }
         };
 
-        SendInput(1, new[] { input }, Marshal.SizeOf(typeof(INPUT)));
+        _ = SendInput(1, new[] { input }, Marshal.SizeOf(typeof(INPUT)));
     }
 
     /// <summary>

--- a/src/WindowsDesktopUse.Screen/CaptureServices/ModernCaptureService.cs
+++ b/src/WindowsDesktopUse.Screen/CaptureServices/ModernCaptureService.cs
@@ -173,7 +173,7 @@ public sealed class HybridCaptureService : ICaptureService, IDisposable
     private Bitmap CaptureWindowLegacy(IntPtr hwnd)
     {
         var hwndLong = hwnd.ToInt64();
-        var imageData = _legacy.CaptureWindow(hwndLong, 1920, 80);
+        var imageData = ScreenCaptureService.CaptureWindow(hwndLong, 1920, 80);
 
         var base64Data = imageData.Contains(";base64,", StringComparison.Ordinal)
             ? imageData.Split(',')[1]

--- a/src/WindowsDesktopUse.Screen/ScreenCaptureService.cs
+++ b/src/WindowsDesktopUse.Screen/ScreenCaptureService.cs
@@ -145,7 +145,7 @@ public class ScreenCaptureService
         }
     }
 
-    private string ToJpegBase64(Bitmap src, int maxW, int q)
+    private static string ToJpegBase64(Bitmap src, int maxW, int q)
     {
         using var ms = new MemoryStream();
         var target = src.Width > maxW ? new Bitmap(src, new Size(maxW, (int)(src.Height * ((double)maxW / src.Width)))) : src;
@@ -199,7 +199,7 @@ public class ScreenCaptureService
         return true;
     }
 
-    public IReadOnlyList<WindowInfo> GetWindows()
+    public static IReadOnlyList<WindowInfo> GetWindows()
     {
         var windows = new List<WindowInfo>();
         var handle = GCHandle.Alloc(windows);
@@ -209,7 +209,7 @@ public class ScreenCaptureService
             {
                 if (!IsWindowVisible(hwnd)) return true;
                 var sb = new System.Text.StringBuilder(256);
-                GetWindowText(hwnd, sb, 256);
+                _ = GetWindowText(hwnd, sb, 256);
                 var title = sb.ToString();
                 if (string.IsNullOrWhiteSpace(title)) return true;
 
@@ -230,7 +230,7 @@ public class ScreenCaptureService
         return windows;
     }
 
-    public string CaptureWindow(long hwnd, int maxW, int quality)
+    public static string CaptureWindow(long hwnd, int maxW, int quality)
     {
         var hWnd = new IntPtr(hwnd);
         if (!IsWindowVisible(hWnd))
@@ -273,7 +273,7 @@ public class ScreenCaptureService
         return ToJpegBase64(bmp, maxW, quality);
     }
 
-    public string CaptureRegion(int x, int y, int w, int h, int maxW, int quality)
+    public static string CaptureRegion(int x, int y, int w, int h, int maxW, int quality)
     {
         if (w <= 0 || h <= 0)
             throw new ArgumentException($"Invalid region dimensions: {w}x{h}");

--- a/src/WindowsDesktopUse.Transcription/WhisperTranscriptionService.cs
+++ b/src/WindowsDesktopUse.Transcription/WhisperTranscriptionService.cs
@@ -94,7 +94,7 @@ public class WhisperTranscriptionService : IDisposable
     /// <summary>
     /// Convert audio to Whisper-compatible format (16kHz, 16bit, mono PCM)
     /// </summary>
-    private string ConvertToWhisperFormat(string inputPath)
+    private static string ConvertToWhisperFormat(string inputPath)
     {
         var outputPath = Path.Combine(Path.GetTempPath(), $"whisper_converted_{Guid.NewGuid()}.wav");
 


### PR DESCRIPTION
- InputService: Mark methods as static (MoveMouse, GetMousePosition, ClickMouseAsync, DragMouseAsync, PressKey, TerminateWindowProcess)
- InputService: Use discard operator for SendInput and GetWindowThreadProcessId return values
- ScreenCaptureService: Mark methods as static (GetWindows, CaptureWindow, CaptureRegion, ToJpegBase64)
- ScreenCaptureService: Use discard operator for GetWindowText return value
- WhisperTranscriptionService: Mark ConvertToWhisperFormat as static
- DesktopUseTools: Update calls to use type name instead of instance for static methods
- ModernCaptureService: Update CaptureWindow call to use type name