### PR TITLE
fix: resolve CA1052 and CA1034 warnings

### DIFF
--- a/src/WindowsDesktopUse.App/DesktopUseTools.cs
+++ b/src/WindowsDesktopUse.App/DesktopUseTools.cs
@@ -16,12 +16,10 @@ public static class DesktopUseTools
     private static ScreenCaptureService? _capture;
     private static AudioCaptureService? _audioCapture;
     private static WhisperTranscriptionService? _whisperService;
-    private static InputService? _inputService;
 
     public static void SetCaptureService(ScreenCaptureService capture) => _capture = capture;
     public static void SetAudioCaptureService(AudioCaptureService audioCapture) => _audioCapture = audioCapture;
     public static void SetWhisperService(WhisperTranscriptionService whisperService) => _whisperService = whisperService;
-    public static void SetInputService(InputService inputService) => _inputService = inputService;
 
     // Enum for capture target types
     public enum CaptureTargetType
@@ -575,7 +573,7 @@ public static class DesktopUseTools
         [Description("X coordinate")] int x,
         [Description("Y coordinate")] int y)
     {
-        if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
+        
         InputService.MoveMouse(x, y);
     }
 
@@ -584,7 +582,7 @@ public static class DesktopUseTools
         [Description("Button: 'left', 'right', 'middle'")] MouseButtonName button = MouseButtonName.Left,
         [Description("Click count")] int count = 1)
     {
-        if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
+        
         if (count < 1) throw new ArgumentOutOfRangeException(nameof(count), "Click count must be at least 1");
 
         var mouseButton = button switch
@@ -605,7 +603,7 @@ public static class DesktopUseTools
         [Description("End X")] int endX,
         [Description("End Y")] int endY)
     {
-        if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
+        
         InputService.DragMouseAsync(startX, startY, endX, endY).GetAwaiter().GetResult();
     }
 
@@ -614,7 +612,7 @@ public static class DesktopUseTools
         [Description("Key name: enter, tab, escape, space, backspace, delete, left, up, right, down, home, end, pageup, pagedown")] string key,
         [Description("Action: 'press', 'release', 'click'")] KeyActionType action = KeyActionType.Click)
     {
-        if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
+        
         if (key == null) throw new ArgumentNullException(nameof(key), "Key cannot be null");
 
         var keyAction = action switch
@@ -627,20 +625,20 @@ public static class DesktopUseTools
 
         var virtualKey = key.ToUpperInvariant() switch
         {
-            "ENTER" or "RETURN" => InputService.VirtualKeys.Enter,
-            "TAB" => InputService.VirtualKeys.Tab,
-            "ESCAPE" or "ESC" => InputService.VirtualKeys.Escape,
-            "SPACE" => InputService.VirtualKeys.Space,
-            "BACKSPACE" => InputService.VirtualKeys.Backspace,
-            "DELETE" or "DEL" => InputService.VirtualKeys.Delete,
-            "LEFT" => InputService.VirtualKeys.Left,
-            "UP" => InputService.VirtualKeys.Up,
-            "RIGHT" => InputService.VirtualKeys.Right,
-            "DOWN" => InputService.VirtualKeys.Down,
-            "HOME" => InputService.VirtualKeys.Home,
-            "END" => InputService.VirtualKeys.End,
-            "PAGEUP" => InputService.VirtualKeys.PageUp,
-            "PAGEDOWN" => InputService.VirtualKeys.PageDown,
+            "ENTER" or "RETURN" => VirtualKeys.Enter,
+            "TAB" => VirtualKeys.Tab,
+            "ESCAPE" or "ESC" => VirtualKeys.Escape,
+            "SPACE" => VirtualKeys.Space,
+            "BACKSPACE" => VirtualKeys.Backspace,
+            "DELETE" or "DEL" => VirtualKeys.Delete,
+            "LEFT" => VirtualKeys.Left,
+            "UP" => VirtualKeys.Up,
+            "RIGHT" => VirtualKeys.Right,
+            "DOWN" => VirtualKeys.Down,
+            "HOME" => VirtualKeys.Home,
+            "END" => VirtualKeys.End,
+            "PAGEUP" => VirtualKeys.PageUp,
+            "PAGEDOWN" => VirtualKeys.PageDown,
             _ => throw new ArgumentException($"Key '{key}' is not allowed or unknown. Allowed keys: enter, tab, escape, space, backspace, delete, arrow keys, home, end, pageup, pagedown")
         };
 
@@ -651,7 +649,7 @@ public static class DesktopUseTools
     public static void CloseWindow(
         [Description("Window handle (HWND) to close")] long hwnd)
     {
-        if (_inputService == null) throw new InvalidOperationException("InputService not initialized");
+        
         InputService.TerminateWindowProcess(new IntPtr(hwnd));
     }
 }

--- a/src/WindowsDesktopUse.App/Program.cs
+++ b/src/WindowsDesktopUse.App/Program.cs
@@ -639,7 +639,6 @@ rootCmd.SetHandler(async (desktop, httpPort, testWhisper) =>
     });
     services.AddSingleton<AudioCaptureService>();
     services.AddSingleton<WhisperTranscriptionService>();
-    services.AddSingleton<InputService>();
 
     serviceProvider = services.BuildServiceProvider();
 
@@ -647,12 +646,10 @@ rootCmd.SetHandler(async (desktop, httpPort, testWhisper) =>
     var captureService = serviceProvider.GetRequiredService<ScreenCaptureService>();
     var audioCaptureService = serviceProvider.GetRequiredService<AudioCaptureService>();
     var whisperService = serviceProvider.GetRequiredService<WhisperTranscriptionService>();
-    var inputService = serviceProvider.GetRequiredService<InputService>();
 
     DesktopUseTools.SetCaptureService(captureService);
     DesktopUseTools.SetAudioCaptureService(audioCaptureService);
     DesktopUseTools.SetWhisperService(whisperService);
-    DesktopUseTools.SetInputService(inputService);
 
     if (testWhisper)
     {

--- a/src/WindowsDesktopUse.Input/InputService.cs
+++ b/src/WindowsDesktopUse.Input/InputService.cs
@@ -27,7 +27,7 @@ public enum KeyAction
 /// Service for mouse and keyboard input operations using SendInput API
 /// Security-restricted: Only safe navigation keys are allowed
 /// </summary>
-public class InputService
+public static class InputService
 {
     [DllImport("user32.dll")]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -341,30 +341,30 @@ public class InputService
 
         _ = SendInput(1, new[] { input }, Marshal.SizeOf(typeof(INPUT)));
     }
+}
 
-    /// <summary>
-    /// Common virtual key codes - Safe navigation keys only
-    /// </summary>
-    public static class VirtualKeys
-    {
-        // Navigation keys
-        public const ushort Enter = 0x0D;
-        public const ushort Tab = 0x09;
-        public const ushort Escape = 0x1B;
-        public const ushort Space = 0x20;
-        public const ushort Backspace = 0x08;
-        public const ushort Delete = 0x2E;
+/// <summary>
+/// Common virtual key codes - Safe navigation keys only
+/// </summary>
+public static class VirtualKeys
+{
+    // Navigation keys
+    public const ushort Enter = 0x0D;
+    public const ushort Tab = 0x09;
+    public const ushort Escape = 0x1B;
+    public const ushort Space = 0x20;
+    public const ushort Backspace = 0x08;
+    public const ushort Delete = 0x2E;
 
-        // Arrow keys
-        public const ushort Left = 0x25;
-        public const ushort Up = 0x26;
-        public const ushort Right = 0x27;
-        public const ushort Down = 0x28;
+    // Arrow keys
+    public const ushort Left = 0x25;
+    public const ushort Up = 0x26;
+    public const ushort Right = 0x27;
+    public const ushort Down = 0x28;
 
-        // Page/Line navigation
-        public const ushort Home = 0x24;
-        public const ushort End = 0x23;
-        public const ushort PageUp = 0x21;
-        public const ushort PageDown = 0x22;
-    }
+    // Page/Line navigation
+    public const ushort Home = 0x24;
+    public const ushort End = 0x23;
+    public const ushort PageUp = 0x21;
+    public const ushort PageDown = 0x22;
 }


### PR DESCRIPTION
- InputService: Mark class as static (CA1052)
- VirtualKeys: Extract nested class to top-level static class (CA1034)
- DesktopUseTools: Update references to use VirtualKeys directly instead of InputService.VirtualKeys
- Program.cs: Remove InputService DI registration and initialization
- Remove _inputService field and SetInputService method from DesktopUseTools